### PR TITLE
Make librato space chart stream composite a computed value

### DIFF
--- a/librato/resource_librato_space_chart.go
+++ b/librato/resource_librato_space_chart.go
@@ -78,6 +78,7 @@ func resourceLibratoSpaceChart() *schema.Resource {
 						"composite": {
 							Type:          schema.TypeString,
 							Optional:      true,
+							Computed:      true,
 							ConflictsWith: []string{"stream.metric", "stream.source", "stream.group_function"},
 						},
 						"summary_function": {


### PR DESCRIPTION
Librato appears to expand any librato.space_chart.stream.metric that is a composite metric in the composite field.