### PR TITLE
Fix panic when removing the attributes block.

### DIFF
--- a/librato/resource_librato_alert.go
+++ b/librato/resource_librato_alert.go
@@ -336,11 +336,9 @@ func resourceLibratoAlertAttributesGather(d *schema.ResourceData, attributes *li
 
 	// Treat an empty hash of attributes as being identical to no attributes set at all.
 	if attributes != nil && attributes.RunbookURL != nil {
-		retAttributes := make(map[string]interface{})
-		if attributes.RunbookURL != nil {
-			retAttributes["runbook_url"] = *attributes.RunbookURL
-		}
-		result = append(result, retAttributes)
+		result = append(result, map[string]interface{}{
+			"runbook_url": *attributes.RunbookURL,
+		})
 	}
 
 	return result
@@ -409,9 +407,9 @@ func resourceLibratoAlertUpdate(d *schema.ResourceData, meta interface{}) error 
 
 		// If no attributes are defined, just set to empty attributes.
 		if !ok {
-			attributes := new(librato.AlertAttributes)
-			attributes.RunbookURL = librato.String("")
-			alert.Attributes = attributes
+			alert.Attributes = &librato.AlertAttributes{
+				RunbookURL: librato.String(""),
+			}
 		} else {
 			attributeData := v.([]interface{})
 			if attributeData[0] == nil {


### PR DESCRIPTION
# Context

When attempting to rollback some changes, I ended up going from this:

```tf
resource "librato_alert" "blach" {
  attributes {
    runbook_url = "https://something"
  }
}
```

to this:
```tf
resource "librato_alert" "blach" {
}
```

When applying this, terraform crashed. I turned on `TF_LOG=trace` and got a trace that brought me to [here](https://github.com/heroku/terraform-provider-librato/blob/master/librato/resource_librato_alert.go#L411). This code was attempting to index into the array, but the array is empty.

# Solution

* Set attributes to an empty attributes object if no attributes are present in the input.
* This exposes another issue where, after applying, we end up getting spurious differences: Terraform always reports that `{}` is not the same as nothing. This is fixed by treating these two values as the same [here](https://github.com/heroku/terraform-provider-librato/blob/e994824b9b4b6bba531eb199512efe7b60d0d330/librato/resource_librato_alert.go#L338).

# Testing

Given that this is on life-support, I have not written any tests - but existing tests all pass.

# Reference

N/A
