### PR TITLE
Update README for a post-module world

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,44 +10,38 @@ Terraform Provider
 Requirements
 ------------
 
--	[Terraform](https://www.terraform.io/downloads.html) 0.10.x
--	[Go](https://golang.org/doc/install) 1.8 (to build the provider plugin)
+-	[Terraform](https://www.terraform.io/downloads.html) 0.12.x
+-	[Go](https://golang.org/doc/install) 1.12 (to build the provider plugin)
 
 Building The Provider
 ---------------------
 
-Clone repository to: `$GOPATH/src/github.com/terraform-providers/terraform-provider-librato`
-
 ```sh
-$ mkdir -p $GOPATH/src/github.com/terraform-providers; cd $GOPATH/src/github.com/terraform-providers
-$ git clone git@github.com:terraform-providers/terraform-provider-librato
-```
-
-Enter the provider directory and build the provider
-
-```sh
-$ cd $GOPATH/src/github.com/terraform-providers/terraform-provider-librato
-$ make build
+git clone git@github.com:heroku/terraform-provider-librato
+cd terraform-provider-librato
+make build
 ```
 
 Using the provider
 ----------------------
 
 ```sh
-export $GOPATH=...
+export $GOPATH=%{GOPATH:-$HOME/go/bin}
 make install
 cp $GOPATH/bin/terraform-provider-librato ~/.terraform.d/plugins
 ```
 
+After recompiling the provider, you will need to re-run `terraform init` init any projects that use it.
+
 Developing the Provider
 ---------------------------
 
-If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.8+ is *required*). You'll also need to correctly setup a [GOPATH](http://golang.org/doc/code.html#GOPATH), as well as adding `$GOPATH/bin` to your `$PATH`.
+If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.12+ is required).
 
 To compile the provider, run `make build`. This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
 
 ```sh
-$ make bin
+$ make build
 ...
 $ $GOPATH/bin/terraform-provider-librato
 ...
@@ -57,12 +51,4 @@ In order to test the provider, you can simply run `make test`.
 
 ```sh
 $ make test
-```
-
-In order to run the full suite of Acceptance tests, run `make testacc`.
-
-*Note:* Acceptance tests create real resources, and often cost money to run.
-
-```sh
-$ make testacc
 ```

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Using the provider
 
 ```sh
 export $GOPATH=%{GOPATH:-$HOME/go/bin}
-make install
+make build
 cp $GOPATH/bin/terraform-provider-librato ~/.terraform.d/plugins
 ```
 


### PR DESCRIPTION
# Context

This project has been updated to use go modules, but documentation is outdated.

# Solution

* Update documentation for go-1.12+

# Testing

Rendered documentation can be seen [here](https://github.com/heroku/terraform-provider-librato/blob/fc3bdeb792468ef999d6a4bf11f649b50f3f5036/README.md).