### PR TITLE
Get the tests green again

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -16,6 +16,9 @@ test: fmtcheck
 testacc: fmtcheck
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m
 
+testaccone: fmtcheck
+	TF_ACC=1 go test $(TEST) -run=$(RUN) -v $(TESTARGS) -timeout 120m
+
 vet:
 	@echo "go vet ."
 	@go vet $$(go list ./... | grep -v vendor/) ; if [ $$? -eq 1 ]; then \

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Terraform Provider
-==================
+# Librato Terraform Provider (v1)
 
 - Website: https://www.terraform.io
 - [![Gitter chat](https://badges.gitter.im/hashicorp-terraform/Lobby.png)](https://gitter.im/hashicorp-terraform/Lobby)
@@ -7,14 +6,12 @@ Terraform Provider
 
 <img src="https://cdn.rawgit.com/hashicorp/terraform-website/master/content/source/assets/images/logo-hashicorp.svg" width="600px">
 
-Requirements
-------------
+## Requirements
 
 -	[Terraform](https://www.terraform.io/downloads.html) 0.12.x
 -	[Go](https://golang.org/doc/install) 1.12 (to build the provider plugin)
 
-Building The Provider
----------------------
+## Building The Provider
 
 ```sh
 git clone git@github.com:heroku/terraform-provider-librato
@@ -22,8 +19,7 @@ cd terraform-provider-librato
 make build
 ```
 
-Using the provider
-----------------------
+## Using the provider
 
 ```sh
 export $GOPATH=%{GOPATH:-$HOME/go/bin}
@@ -33,8 +29,7 @@ cp $GOPATH/bin/terraform-provider-librato ~/.terraform.d/plugins
 
 After recompiling the provider, you will need to re-run `terraform init` init any projects that use it.
 
-Developing the Provider
----------------------------
+## Developing the Provider
 
 If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.12+ is required).
 
@@ -47,8 +42,33 @@ $ $GOPATH/bin/terraform-provider-librato
 ...
 ```
 
-In order to test the provider, you can simply run `make test`.
+### Running tests
+
+#### Unit tests
 
 ```sh
 $ make test
+```
+
+#### Acceptance tests
+
+Acceptance tests send requests against the Librato API. Hit the [Librato UI](https://metrics.librato.com/tokens) and create a token. The Email should be popiulated for you automatically and the token will be generated. You will want a Full Access token as you'll be creating (and tearing down) Librato resources.
+
+```sh
+export LIBRATO_EMAIL=<email>
+export LIBRATO_TOKEN=<token>
+
+make testacc
+```
+
+If you want to run a single acceptance test:
+
+```sh
+export LIBRATO_EMAIL=<email>
+export LIBRATO_TOKEN=<token>
+
+# example: TestAccLibratoAlert_Rename
+RUN=TestAccLibratoAlert_Rename make testaccone
+# or
+make RUN=TestAccLibratoAlert_Rename testaccone
 ```

--- a/librato/resource_librato_alert_test.go
+++ b/librato/resource_librato_alert_test.go
@@ -265,6 +265,12 @@ func testAccCheckLibratoAlertConfig_minimal(name string) string {
 	return fmt.Sprintf(`
 resource "librato_alert" "foobar" {
     name = "%s"
+    condition {
+      type = "above"
+      threshold = 10
+      duration = 600
+      metric_name = "librato.cpu.percent.idle"
+    }
 }`, name)
 }
 
@@ -273,6 +279,12 @@ func testAccCheckLibratoAlertConfig_basic(name string) string {
 resource "librato_alert" "foobar" {
     name = "%s"
     description = "A Test Alert"
+    condition {
+      type = "above"
+      threshold = 10
+      duration = 600
+      metric_name = "librato.cpu.percent.idle"
+    }
 }`, name)
 }
 
@@ -281,6 +293,12 @@ func testAccCheckLibratoAlertConfig_new_value(name string) string {
 resource "librato_alert" "foobar" {
     name = "%s"
     description = "A modified Test Alert"
+    condition {
+      type = "above"
+      threshold = 10
+      duration = 600
+      metric_name = "librato.cpu.percent.idle"
+    }
 }`, name)
 }
 

--- a/librato/resource_librato_space_chart_test.go
+++ b/librato/resource_librato_space_chart_test.go
@@ -170,6 +170,8 @@ resource "librato_space_chart" "foobar" {
     space_id = "${librato_space.foobar.id}"
     name = "Foo Bar"
     type = "line"
+    min = 0
+    max = 100
 }`
 
 const testAccCheckLibratoSpaceChartConfig_new_value = `
@@ -181,6 +183,8 @@ resource "librato_space_chart" "foobar" {
     space_id = "${librato_space.foobar.id}"
     name = "Bar Baz"
     type = "line"
+    min = 0
+    max = 100
 }`
 
 const testAccCheckLibratoSpaceChartConfig_full = `
@@ -205,11 +209,15 @@ resource "librato_space_chart" "foobar" {
     stream {
         metric = "librato.cpu.percent.idle"
         source = "*"
+        min = 0
+        max = 100
     }
 
     # Minimal composite stream
     stream {
         composite = "s(\"cpu\", \"*\")"
+        min = 0
+        max = 100
     }
 
     # Full metric stream


### PR DESCRIPTION
This provider has not been kept up to date, and several of the tests were not passing. I updated many of the tests based on (newish) required fields that the API expects, and also updated the README to make it easier for contributors to get started.

Once this is merged, I'll update the provider for Terraform v0.12.

Note: I'm not sure of the status of https://github.com/heroku/terraform-provider-librato/pull/4, but it takes a bit different approach; I'm not sure which should take precedence here, but am open to suggestions.