### PR TITLE
Add project to Terraform registry?

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Requirements
 
--	[Terraform](https://www.terraform.io/downloads.html) 0.12.x
+-	[Terraform](https://www.terraform.io/downloads.html) 0.12.x+
 -	[Go](https://golang.org/doc/install) 1.14 (to build the provider plugin)
 
 ## Building The Provider


### PR DESCRIPTION
Hey thanks for maintaining this fork.
We've been using it since our upgrade to terraform 0.12 and it works great.

Recently we've been on an upgrade path going from `0.13` -> `0.14` -> `0.15` and with the recent changes introduced by Terraform to the providers versioning and lock file setup, it is now quite convoluted to get the provider to work properly by loading it locally.

It would be amazing if we could add it to the Terraform Registry so we can just reference the provider from the registry and avoid faffing with custom local build setups.

The publishing should be quite straightforward with Github Actions: https://www.terraform.io/docs/registry/providers/publishing.html

cc. @wchrisjohnson @sheax0r